### PR TITLE
Add basic CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+dist: trusty
+language: rust
+rust:
+  - nightly
+cache:
+  yarn: true
+  cargo: true
+jobs:
+  include:
+  - stage: unit-tests
+    script: cd titan-web-client && yarn && yarn test
+  - stage: unit-tests
+    script: cd titan-server && cargo test
+  - stage: deploy-staging
+    script: skip
+

--- a/titan-server/src/lib.rs
+++ b/titan-server/src/lib.rs
@@ -1,3 +1,11 @@
 pub fn hello() {
     println!("Hello from Project Titan!");
 }
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn it_works() {
+        assert_eq!(4, 2+2);
+    }
+}

--- a/titan-web-client/package.json
+++ b/titan-web-client/package.json
@@ -21,7 +21,7 @@
     "build": "yarn run setup && react-scripts build",
     "test": "yarn run setup && mocha --compilers babel-core/register ./src/**/*.test.js",
     "eject": "react-scripts eject",
-    "setup": "sh ./scripts/setup.sh"
+    "setup": "./scripts/setup.sh"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/titan-web-client/scripts/setup.sh
+++ b/titan-web-client/scripts/setup.sh
@@ -5,8 +5,8 @@ APP_PATH="${SCRIPT_PATH}/.."
 
 for d in src/*/; do
     if [[ ${d} = *"titan-"* ]]; then
-         MODULE_PATH=$(cut -d "/" -f 2 <<< "${d}")
-         echo "Linking module: ${MODULE_PATH}"
+        MODULE_PATH=$(cut -d "/" -f 2 <<< "${d}")
+        echo "Linking module: ${MODULE_PATH}"
 
         cd "${APP_PATH}/${d}"
         yarn link > /dev/null 2>&1


### PR DESCRIPTION
Uses Travis-CI and uses build stages so that (future) deployments are
only deployed on success of unit tests on the frontend and backend.

[#155073677]