### PR TITLE
Implemented text field

### DIFF
--- a/titan-web-client/package.json
+++ b/titan-web-client/package.json
@@ -15,6 +15,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "color": "^3.0.0",
+    "lodash": "^4.17.5",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",

--- a/titan-web-client/src/titan-components/form/FormControl.js
+++ b/titan-web-client/src/titan-components/form/FormControl.js
@@ -1,0 +1,161 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import color from 'color'
+import WithTheme from '../../titan-core/components/WithTheme'
+import FormControlFactory from './FormControlFactory'
+import _ from 'lodash'
+
+export const FormControlInput = styled(FormControlFactory)`
+  width: 100%;
+  min-height: 1.5rem;
+  font-size: inherit;
+  font-family: inherit;
+  line-height: 1.5rem;
+  color: inherit;
+  padding: 8px;
+  border: none;
+  outline: none;
+  background-color: transparent;
+  display: flex;
+  flex: 1;
+`
+
+export const FormControlSideLabel = styled.div`
+    height: 100%;  
+    font-size: .8rem;
+    font-weight: 500;
+    text-align: center;
+    cursor: ${props => props.hasAction ? 'pointer' : 'default'};
+    margin-left: 8px;
+    align-self: center;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: -ms-flexbox;
+    display: flex;
+`
+
+export const FormControlWrapper = styled.div`
+  width: ${props => props.fullWidth ? '100%' : '260px'};
+  color: ${props => props.textColor};
+  margin: 3px;
+  border: 2px solid ${props => props.borderColor};
+  border-radius: 3px;
+  display: flex;
+  flex-direction: row;
+  
+  ${FormControlSideLabel} {
+    color: ${props => color(props.textColor).fade(.8).toString()}
+  }
+  
+  ${FormControlSideLabel}:first-child {
+      margin-left: 8px;
+  }
+  
+  ${FormControlSideLabel}:last-child {
+      margin-right: 8px;
+  }
+`
+
+class FormControl extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      isFocused: false
+    }
+  }
+
+  onInputFocus () {
+    this.setState({ isFocused: true }, () => {
+      this.props.onFocusChange(this.state.isFocused)
+    })
+  }
+
+  onInputFocusOut () {
+    this.setState({ isFocused: false }, () => {
+      this.props.onFocusChange(this.state.isFocused)
+    })
+  }
+
+  render () {
+    const {
+      fullWidth,
+      labelLeft,
+      labelRight,
+      onLabelLeftClick,
+      onLabelRightClick,
+      ...rest
+    } = this.props
+    const children = []
+
+    if (labelLeft) {
+      children.push(
+        <FormControlSideLabel
+          hasAction={_.isFunction(onLabelLeftClick)}
+          onClick={onLabelLeftClick}
+        >
+          {labelLeft}
+        </FormControlSideLabel>
+      )
+    }
+
+    children.push(
+      <FormControlInput
+        {...rest}
+        onFocus={this.onInputFocus.bind(this)}
+        onBlur={this.onInputFocusOut.bind(this)}
+      >
+        {this.props.children}
+      </FormControlInput>
+    )
+
+    if (labelRight) {
+      children.push(
+        <FormControlSideLabel
+          hasAction={_.isFunction(onLabelRightClick)}
+          onClick={onLabelRightClick}
+        >
+          {labelRight}
+        </FormControlSideLabel>
+      )
+    }
+
+    let borderColor
+    if (this.state.isFocused) {
+      borderColor = this.props.titanTheme.palette.primary
+    } else {
+      borderColor = this.props.titanTheme.palette.neutral
+    }
+
+    return (
+      <FormControlWrapper
+        fullWidth={fullWidth}
+        textColor={this.props.titanTheme.palette.textPrimary}
+        borderColor={borderColor}
+        focusBorderColor={this.props.titanTheme.palette.primary}>
+        {children}
+      </FormControlWrapper>
+    )
+  }
+}
+
+FormControl.propTypes = {
+  control: PropTypes.any,
+  type: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onFocusChange: PropTypes.func,
+  labelLeft: PropTypes.any,
+  labelRight: PropTypes.func,
+  onLabelLeftClick: PropTypes.func,
+  onLabelRightClick: PropTypes.func,
+  fullWidth: PropTypes.bool
+}
+
+FormControl.defaultProps = {
+  onFocusChange: () => {},
+  fullWidth: false
+}
+
+export default WithTheme(FormControl)

--- a/titan-web-client/src/titan-components/form/FormControlFactory.js
+++ b/titan-web-client/src/titan-components/form/FormControlFactory.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import _ from 'lodash'
+
+class FormControlFactory extends React.Component {
+  renderNativeControl(control, props) {
+    switch (control) {
+      case 'textarea':
+        return <textarea {...props} />
+      default:
+        return <input {...props} />
+    }
+  }
+
+  render () {
+    const { control, ...rest } = this.props
+
+    if (_.isEmpty(control) || typeof control === 'string') {
+      return this.renderNativeControl(control, rest)
+    }
+
+    const ControlComponent = control
+    return <ControlComponent {...rest} />
+  }
+}
+
+FormControlFactory.propTypes = {
+  control: PropTypes.any
+}
+
+FormControlFactory.defaultProps = {
+  type: 'text'
+}
+
+export default FormControlFactory

--- a/titan-web-client/src/titan-components/form/index.js
+++ b/titan-web-client/src/titan-components/form/index.js
@@ -1,0 +1,11 @@
+import {
+  FormControlInput,
+  FormControlSideLabel,
+  FormControlWrapper,
+} from './FormControl'
+
+export const styles = {
+  FormControlWrapper,
+  FormControlInput,
+  FormControlSideLabel
+}

--- a/titan-web-client/src/titan-components/index.js
+++ b/titan-web-client/src/titan-components/index.js
@@ -1,3 +1,4 @@
 export {default as Button} from './button'
 export {default as FlatButton} from './flatButton'
 export {default as ContentBlock} from './block/ContentBlock'
+export {default as TextField} from './textField/TextField'

--- a/titan-web-client/src/titan-components/textField/TextField.js
+++ b/titan-web-client/src/titan-components/textField/TextField.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import WithTheme from '../../titan-core/components/WithTheme'
+import FormControl from '../form/FormControl'
+
+class TextField extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      isFocused: false
+    }
+  }
+
+  render () {
+    const { multiLine, ...rest} = this.props
+    const control = multiLine ? 'textarea' : 'text';
+
+    return (
+      <FormControl {...rest} control={control}>
+        {this.props.children}
+      </FormControl>
+    )
+  }
+}
+
+TextField.propTypes = {
+  type: PropTypes.string,
+  placeholder: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+  onFocusChange: PropTypes.func,
+  labelLeft: PropTypes.any,
+  labelRight: PropTypes.func,
+  fullWidth: PropTypes.bool,
+  multiLine: PropTypes.string,
+  onLabelLeftClick: PropTypes.func,
+  onLabelRightClick: PropTypes.func
+}
+
+TextField.defaultProps = {
+  onFocusChange: () => {},
+  fullWidth: false,
+  multiLine: false,
+  onLabelLeftClick: null,
+  onLabelRightClick: null
+}
+
+export default WithTheme(TextField)

--- a/titan-web-client/src/titan-components/textField/index.js
+++ b/titan-web-client/src/titan-components/textField/index.js
@@ -1,0 +1,3 @@
+import TextField from './TextField'
+
+export default TextField

--- a/titan-web-client/yarn.lock
+++ b/titan-web-client/yarn.lock
@@ -4504,7 +4504,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
# Text Fields
Implemented simple text fields, including additional boilerplate code needed for similar inputs that have not been implemented (select, date).

![titan_inputs](https://user-images.githubusercontent.com/2666285/36941859-cf2129be-1f32-11e8-92c7-e4aab7a32773.PNG)

## Usage Examples

```jsx harmony
<h3>Simple Text</h3>
<TextField />

<h3>Email</h3>
<TextField
  labelLeft={<FontAwesomeIcon icon={faEnvelope} />}
  type="email"
/>

<h3>Number</h3>
<TextField
  labelRight={'min'}
  placeholder="Duration"
  type="number"
/>

<h3>Multi-line</h3>

<TextField
  rows={5}
  multiLine
  placeholder="Description..."
/>
```

## Available props

```javascript
{
  type: PropTypes.string,
  placeholder: PropTypes.string,
  value: PropTypes.string,
  onChange: PropTypes.func,
  onFocusChange: PropTypes.func,
  labelLeft: PropTypes.any,
  labelRight: PropTypes.func,
  fullWidth: PropTypes.bool,
  multiLine: PropTypes.string,
  onLabelLeftClick: PropTypes.func,
  onLabelRightClick: PropTypes.func
}
```