### PR TITLE
Added flat icon buttons

### DIFF
--- a/titan-web-client/package.json
+++ b/titan-web-client/package.json
@@ -19,6 +19,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
+    "react-ink": "^6.2.0",
     "react-redux": "^5.0.6",
     "react-router-dom": "^4.2.2",
     "react-scripts": "1.1.0",

--- a/titan-web-client/src/titan-components/button/Button.js
+++ b/titan-web-client/src/titan-components/button/Button.js
@@ -9,6 +9,7 @@ export const ButtonWrapper = styled.div`
   width: ${props => props.fullWidth ? '100%' : 'auto'};
   display: ${props => props.fullWidth ? 'block' : 'inline-block'};
   margin: 3px;
+  position: relative;
   
   ${BaseButtonWrapper} {
     display: block;

--- a/titan-web-client/src/titan-components/effects/Ripple.js
+++ b/titan-web-client/src/titan-components/effects/Ripple.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import Ink from 'react-ink'
+import styled from 'styled-components'
+
+export const RippleWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: inline-block;
+  position: absolute;
+  top: 0;
+  left: 0;
+`
+
+class Ripple extends React.Component {
+  render () {
+    return (
+      <RippleWrapper>
+        {this.props.children}
+        <Ink {...this.props} />
+      </RippleWrapper>
+    )
+  }
+}
+
+export default Ripple

--- a/titan-web-client/src/titan-components/iconButton/IconButton.js
+++ b/titan-web-client/src/titan-components/iconButton/IconButton.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import Ripple from '../effects/Ripple'
+import BaseButton, { BaseButtonWrapper } from '../baseButton/BaseButton'
+
+export const IconButtonWrapper = styled.div`
+  display: inline-block;
+  position: relative;
+  border-radius: 100%;
+  padding: .5rem .6rem;
+  
+  ${BaseButtonWrapper} {
+    padding: 0;
+    background: transparent;
+  }
+`
+
+class IconButton extends React.Component {
+  render () {
+    return (
+      <IconButtonWrapper size={this.props.size}>
+        <BaseButton>
+          {this.props.icon}
+          <Ripple style={{borderRadius: "100%"}} />
+        </BaseButton>
+      </IconButtonWrapper>
+    )
+  }
+}
+
+IconButton.propTypes = {
+  icon: PropTypes.func
+}
+
+export default IconButton

--- a/titan-web-client/yarn.lock
+++ b/titan-web-client/yarn.lock
@@ -5793,6 +5793,10 @@ react-error-overlay@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-4.0.0.tgz#d198408a85b4070937a98667f500c832f86bd5d4"
 
+react-ink@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/react-ink/-/react-ink-6.2.0.tgz#b268107bf986c6009bd38d7d3baa9fba1016e368"
+
 react-redux@^5.0.6:
   version "5.0.6"
   resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-5.0.6.tgz#23ed3a4f986359d68b5212eaaa681e60d6574946"


### PR DESCRIPTION
# Icon Button
This type of button will be used for triggering actions where a typical button would not appropriately fit in with the surrounding UI.

- notification toggle
- context menus
- table actions

I thought a material approach would make the most sense for this kind of control.

## Usage
![titan_flat_button](https://user-images.githubusercontent.com/2666285/37264510-0eb7aa6a-2584-11e8-9b2e-b90909af39fd.gif)

```jsx harmony
<IconButton
    icon={<FontAwesome icon={User} />} 
/>
```