### PR TITLE
Remove one more cookie to log out of Woltlab

### DIFF
--- a/titan-web-client/src/modules/auth/logout/index.js
+++ b/titan-web-client/src/modules/auth/logout/index.js
@@ -16,6 +16,10 @@ class LogoutScene extends React.Component {
       path: '/',
       domain: this.props.config.get('woltlab.cookie.domain')
     });
+    this.props.cookies.remove('wcf21_cookieHash', {
+      path: '/',
+      domain: this.props.config.get('woltlab.cookie.domain')
+    });
     this.props.actions.auth.logout();
     window.location = '/auth/login';
   }


### PR DESCRIPTION
The cookieHash cookie needs to be removed, as well, to log out of
Woltlab when you log out of Titan

#### Before you submit this PR for review, make sure the following tasks are complete.

- [x] Added relevant documentation.
- [x] Updated unit tests.
- [x] Made sure all tests are passing with `yarn test`
- [x] Ensured all code meets the [standard JS](https://standardjs.com) style guide.
- [x] Removed debug code.
- [x] Included screenshot if applicable.
- [x] Squashed changes into a single commit.
- [x] If adding new routes to the frontend application, specify them below for testing

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
