### PR TITLE
Wrapped LOA access in ACL check.

### DIFF
--- a/titan-server/src/accounts/acl.rs
+++ b/titan-server/src/accounts/acl.rs
@@ -3,7 +3,7 @@ use diesel::{prelude::*, MysqlConnection};
 use crate::models;
 use crate::schema;
 
-pub fn get_user_acl(user_id: i32, wcf_db: &MysqlConnection) -> QueryResult<Vec<models::WcfAclOption>> {
+pub fn get_user_acl(wcf_user_id: i32, wcf_db: &MysqlConnection) -> QueryResult<Vec<models::WcfAclOption>> {
     let mut acl_option_ids = schema::wcf1_user_to_group::table
         .inner_join(schema::wcf1_acl_option_to_group::table.on(
             schema::wcf1_acl_option_to_group::group_id.eq(
@@ -11,7 +11,7 @@ pub fn get_user_acl(user_id: i32, wcf_db: &MysqlConnection) -> QueryResult<Vec<m
             )
         ))
         .select(schema::wcf1_acl_option_to_group::option_id)
-        .filter(schema::wcf1_user_to_group::user_id.eq(user_id))
+        .filter(schema::wcf1_user_to_group::user_id.eq(wcf_user_id))
         .filter(schema::wcf1_acl_option_to_group::option_value.eq(true))
         .group_by(schema::wcf1_acl_option_to_group::option_id)
         .load::<i32>(wcf_db)
@@ -19,7 +19,7 @@ pub fn get_user_acl(user_id: i32, wcf_db: &MysqlConnection) -> QueryResult<Vec<m
 
     let mut user_acl_option_ids = schema::wcf1_acl_option_to_user::table
         .select(schema::wcf1_acl_option_to_user::option_id)
-        .filter(schema::wcf1_acl_option_to_user::user_id.eq(user_id))
+        .filter(schema::wcf1_acl_option_to_user::user_id.eq(wcf_user_id))
         .filter(schema::wcf1_acl_option_to_user::option_value.eq(true))
         .load::<i32>(wcf_db)
         .expect("failed to load user acl option ids");
@@ -31,4 +31,20 @@ pub fn get_user_acl(user_id: i32, wcf_db: &MysqlConnection) -> QueryResult<Vec<m
     schema::wcf1_acl_option::table
         .filter(schema::wcf1_acl_option::id.eq_any(acl_option_ids))
         .load::<models::WcfAclOption>(wcf_db)
+}
+
+/// Returns true a user has permission for the given ACL option.
+pub fn has_acl_option(wcf_user_id: i32, option_name: &str, wcf_db: &MysqlConnection) -> bool {
+    let options_res = get_user_acl(wcf_user_id, wcf_db);
+
+    if options_res.is_ok() {
+        let options = options_res.unwrap();
+        for option in options {
+            if option.option_name == option_name {
+                return true;
+            }
+        }
+    }
+
+    false
 }

--- a/titan-server/src/models.rs
+++ b/titan-server/src/models.rs
@@ -134,9 +134,9 @@ pub struct WcfAclOptionCategory {
 
 #[derive(Serialize, Deserialize, Queryable)]
 pub struct WcfAclOption {
-    id: i32,
-    option_name: String,
-    category_name: String
+    pub id: i32,
+    pub option_name: String,
+    pub category_name: String
 }
 
 #[derive(Serialize, Deserialize, Queryable)]


### PR DESCRIPTION
resolves #76 

I'm sure there is a more elegant solution to this issue. For now, I hard-coded a check for LOA permissions until this use case expands to other file entry types.

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```

## Setup
Do we have a migration process for WCF? We need to add a new `canViewLoa` ACL option and assign it to NCO's and command.