### PR TITLE
Fixed COC order

### DIFF
--- a/titan-web-client/src/modules/organizations/components/OrganizationChainOfCommand.js
+++ b/titan-web-client/src/modules/organizations/components/OrganizationChainOfCommand.js
@@ -28,8 +28,8 @@ export class OrganizationChainOfCommand extends React.Component {
     this.organizationsService.findChainOfCommand(organizationId)
       .then(res => {
         this.setState({
-          extendedCoc: res.data.extended_coc,
-          localCoc: res.data.local_coc
+          extendedCoc: res.data.extended_coc.reverse(),
+          localCoc: res.data.local_coc.reverse()
         });
       });
   }
@@ -37,8 +37,8 @@ export class OrganizationChainOfCommand extends React.Component {
   render () {
     return (
       <ChainOfCommand
-        extendedCoc={this.state.extendedCoc.reverse()}
-        localCoc={this.state.localCoc.reverse()}
+        extendedCoc={this.state.extendedCoc}
+        localCoc={this.state.localCoc}
       />
     );
   }


### PR DESCRIPTION
Resolves #125 

The COC endpoint orders roles by rank, where the least ranking member is first in the list. The Org COC component reverses the list before rendering so the highest ranking role appears first. There is a subtle bug where the list is being reversed in the `render()` method. The method is called many times on page load, causing the list to be rapidly reversed an indeterminate number of times.

That is why the list may be correct on page load, but reversed after reloading.

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
