### PR TITLE
Hide inactive units from CoC detail

### DIFF
--- a/titan-web-client/src/modules/organizations/organizationDetail/Overview.js
+++ b/titan-web-client/src/modules/organizations/organizationDetail/Overview.js
@@ -64,7 +64,7 @@ export class Overview extends React.Component {
                   <OrganizationChainOfCommand
                     organizationId={this.props.organizationId} />
                   <CoCActions>
-                    {this.state.childOrgs.map((org, key) => (
+                    {this.state.childOrgs.filter(childOrg => childOrg.is_enabled).map((org, key) => (
                       <Button
                         color="secondary"
                         component={RouteButton}


### PR DESCRIPTION
Doesn't display buttons to inactive units in the chain of command so as
to not link to unviewable resources.

Resolves #137

#### Before you submit this PR for review, make sure the following tasks are complete.

- [x] Added relevant documentation.
- [x] Updated unit tests.
- [x] Made sure all tests are passing with `yarn test`
- [x] Ensured all code meets the [standard JS](https://standardjs.com) style guide.
- [x] Removed debug code.
- [x] Included screenshot if applicable.
- [x] Squashed changes into a single commit.
- [x] If adding new routes to the frontend application, specify them below for testing

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
