### PR TITLE
155 Added size variants to MemberNameTag component

### DIFF
--- a/titan-web-client/src/components/members/MemberNameTag.js
+++ b/titan-web-client/src/components/members/MemberNameTag.js
@@ -4,29 +4,68 @@ import Avatar from '@material-ui/core/Avatar';
 import styled from 'styled-components';
 import { Typography } from '@material-ui/core';
 
-/**
- * Displays general information about a titan user, including their
- * name and an optional label (i.e. role, organization, etc.).
- *
- * {@code
- * <MemberNameTag
- *   avatarUrl={avatarUrl}
- *   avatarPosition="left"
- *   label={organizationName}
- *   labelPosition="below"
- *   username={username}"
- * />
- * }
- */
 export const StyledMemberNameTag = styled.div`
   align-items: center;
   display: flex;
   flex-direction: ${props => props.avatarPosition === 'top' ? 'column' : 'row'};
   text-align: ${props => props.avatarPosition === 'top' ? 'center' : props.avatarPosition};
+  
+  .username {
+    font-size: 14px;
+  }
+
+  .detail-label {
+    font-size: 12px;
+  }
+
+  &.small {
+    .avatar {
+      height: 32px;
+      width: 32px;
+    }
+    
+    .username {
+      font-size: 16px;
+    }
+    
+    .detail-label {
+      font-size: 13px;
+    }
+  }
+  
+  &.medium {
+    .avatar {
+      height: 36px;
+      width: 36px;
+    }
+  
+    .username {
+      font-size: 16px;
+    }
+  
+    .detail-label {
+      font-size: 13px;
+    }
+  }
+  
+  &.large {
+    .avatar {
+      height: 48px;
+      width: 48px;
+    }
+
+    .username {
+      font-size: 16px;
+    }
+
+    .detail-label {
+      font-size: 14px;
+    }
+  }
 
   .avatar {
-    height: 50px;
-    width: 50px;
+    height: 24px;
+    width: 24px;
 
     &.top {
       margin-bottom: 8px;
@@ -53,19 +92,34 @@ export const StyledMemberNameTagDetails = styled.div`
   }
 `;
 
+/**
+ * Displays general information about a titan user, including their
+ * name and an optional label (i.e. role, organization, etc.).
+ *
+ * @example
+ * <MemberNameTag
+ *   avatarUrl={avatarUrl}
+ *   avatarPosition="left"
+ *   label={organizationName}
+ *   labelPosition="below"
+ *   username={username}"
+ * />
+ */
 export function MemberNameTag (props) {
   const avatarClass = `avatar ${props.avatarPosition}`;
   return (
-    <StyledMemberNameTag avatarPosition={props.avatarPosition}>
+    <StyledMemberNameTag avatarPosition={props.avatarPosition} className={props.size}>
       <Avatar
         className={avatarClass}
         component="div"
         src={props.avatarUrl}
       />
       <StyledMemberNameTagDetails labelPosition={props.labelPosition}>
-        <Typography component="div">{props.username}</Typography>
+        <Typography component="div" className="username">
+          {props.username}
+        </Typography>
         <Typography
-          className="profile-label"
+          className="detail-label"
           color="textSecondary"
           component="div">{props.label}</Typography>
       </StyledMemberNameTagDetails>
@@ -78,5 +132,12 @@ MemberNameTag.propTypes = {
   avatarPosition: PropTypes.oneOf(['left', 'right', 'top']),
   label: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   labelPosition: PropTypes.oneOf(['above', 'below']),
-  username: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired
+  username: PropTypes.oneOfType([PropTypes.object, PropTypes.string]).isRequired,
+  size: PropTypes.oneOf(['small', 'medium', 'large'])
+};
+
+MemberNameTag.defaultProps = {
+  avatarPosition: 'left',
+  labelPosition: 'below',
+  size: ''
 };

--- a/titan-web-client/src/components/members/table/UserRow.js
+++ b/titan-web-client/src/components/members/table/UserRow.js
@@ -11,6 +11,7 @@ import { Menu } from '@material-ui/core';
 import MenuItem from '@material-ui/core/MenuItem';
 import IconButton from '@material-ui/core/IconButton';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
+import { MemberNameTag } from 'titan/components/members/MemberNameTag';
 
 /**
  * @param {{user: {}, onRemove: Function}} props
@@ -18,6 +19,7 @@ import MoreVertIcon from '@material-ui/icons/MoreVert';
 export function UserRow (props) {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const isOpen = Boolean(anchorEl);
+  const orgRoute = routeBuilder(USER_PROFILE_ROUTE, [props.user.id]);
 
   function removeUser () {
     setAnchorEl(undefined);
@@ -27,17 +29,11 @@ export function UserRow (props) {
   return (
     <TableRow key={props.user.id} hover>
       <TableCell>
-        <Row>
-          <Column>
-            <Avatar
-              style={{ width: 20, height: 20 }}
-              src={props.user.wcf.avatar_url}
-            />
-          </Column>
-          <Column>
-            <RouteLink to={routeBuilder(USER_PROFILE_ROUTE, [props.user.id])}>{props.user.username}</RouteLink>
-          </Column>
-        </Row>
+        <MemberNameTag
+          avatarUrl={props.user.wcf.avatar_url}
+          username={<RouteLink to={orgRoute}>{props.user.username}</RouteLink>}
+          size="small"
+        />
       </TableCell>
       <TableCell>{formatDate(props.user.wcf.last_activity_time,
         'MMMM dd, yyyy')}</TableCell>

--- a/titan-web-client/src/modules/organizations/components/ChainOfCommand.js
+++ b/titan-web-client/src/modules/organizations/components/ChainOfCommand.js
@@ -164,6 +164,7 @@ class ChainOfCommandComponent extends React.Component {
           )}
           labelPosition="below"
           username={coc.user_profile.wcf.username}
+          size="large"
         />
       </Leaf>
     );

--- a/titan-web-client/src/modules/organizations/organizationDetail/Overview.js
+++ b/titan-web-client/src/modules/organizations/organizationDetail/Overview.js
@@ -11,6 +11,7 @@ import { ListSupportLeadership } from 'titan/modules/organizations/components/Li
 import Button from '@material-ui/core/Button';
 import styled from 'styled-components';
 import { RouteButton } from 'titan/components/Routes/RouteLink';
+import { MemberNameTag } from 'titan/components/members/MemberNameTag';
 
 const CoCActions = styled.div`
   font-size: 12px;


### PR DESCRIPTION
Resolves #155 

- Adds size variants to component.
- Updates member list view to use the component.

![titan_membernametag_size2](https://user-images.githubusercontent.com/2666285/64590251-f6f13b80-d35b-11e9-8854-3e842d028ac0.png)


    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
