### PR TITLE
Refactored roles endpoints

### DIFF
--- a/titan-server/src/organizations/mod.rs
+++ b/titan-server/src/organizations/mod.rs
@@ -14,6 +14,7 @@ pub fn get_routes() -> Vec<Route> {
         routes::get_all_unacknowledged_reports,
         routes::get_organization_by_id,
         routes::get_organization_by_slug,
+        routes::get_organization_roles,
         routes::get_organization_users,
         routes::get_parent_role,
         routes::list_organization_roles,

--- a/titan-server/src/organizations/routes.rs
+++ b/titan-server/src/organizations/routes.rs
@@ -13,6 +13,7 @@ use crate::accounts;
 use crate::guards::form::NaiveDateTimeForm;
 use crate::accounts::file_entries;
 use crate::guards::auth_guard;
+use crate::organizations::roles::RoleRankScope;
 
 #[derive(Serialize)]
 pub struct FindOrganizationResponse {
@@ -229,6 +230,22 @@ pub fn get_organization_coc(
         org_id, std::i32::MAX, &*titan_db, &*wcf_db, &app_config).unwrap())
 }
 
+#[get("/<org_id>/roles?<scope>")]
+pub fn get_organization_roles(
+    org_id: i32,
+    scope: RoleRankScope,
+    titan_db: TitanPrimary,
+    wcf_db: UnksoMainForums,
+    app_config: State<config::AppConfig>,
+    _auth_user: auth_guard::AuthenticatedUser
+) -> Json<Vec<models::OrganizationRoleWithAssoc>> {
+    let roles = organizations::roles::find_org_roles(
+        org_id, scope, &*titan_db).unwrap();
+    Json(organizations::roles::map_roles_assoc(
+        roles, &*titan_db, &*wcf_db, &app_config).unwrap())
+}
+
+/// [deprecated(note = "Use get_organization_roles instead.")]
 #[get("/<org_id>/roles/unranked")]
 pub fn get_organization_unranked_roles(
     org_id: i32,

--- a/titan-web-client/src/http/ApiClient.js
+++ b/titan-web-client/src/http/ApiClient.js
@@ -59,6 +59,37 @@ export function ListUsersRequest (fields = {}) {
   };
 }
 
+export const ROLE_SCOPES = {
+  RANKED: 0,
+  SUPPORT: 1,
+  ALL: 2
+};
+
+/**
+ * Lists an organization's roles.
+ *
+ * @param {{orgId: number, scope: string}} fields
+ * @returns {{
+ *  auth: boolean,
+ *  config: {method: string, params: {limit, username}, url: string}
+ * }}
+ */
+export function ListOrganizationRoles (fields = {}) {
+  let { orgId, scope } = fields;
+  if (scope === undefined) {
+    scope = ROLE_SCOPES.ALL;
+  }
+
+  return {
+    auth: false,
+    config: {
+      url: `/organizations/${orgId}/roles`,
+      method: 'get',
+      params: { scope }
+    }
+  };
+}
+
 /**
  * Lists all users in an organization.
  *


### PR DESCRIPTION
Adds a single route for fetching an organization's ranked/unranked roles. Deprecates others. This is necessary for upcoming organization management work.

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
