### PR TITLE
158 API endpoint to reorder an organization's roles

### DIFF
--- a/titan-server/src/models.rs
+++ b/titan-server/src/models.rs
@@ -216,6 +216,13 @@ pub struct OrganizationRole {
     pub rank: Option<i32>
 }
 
+#[derive(AsChangeset)]
+#[table_name = "organization_roles"]
+#[changeset_options(treat_none_as_null="true")]
+pub struct OrganizationRoleRankChangeSet {
+    pub rank: Option<i32>
+}
+
 #[derive(Serialize)]
 pub struct OrganizationRoleWithAssoc {
     pub id: i32,

--- a/titan-server/src/organizations/mod.rs
+++ b/titan-server/src/organizations/mod.rs
@@ -25,5 +25,6 @@ pub fn get_routes() -> Vec<Route> {
         routes::list_organization_reports,
         routes::list_organization_user_file_entries,
         routes::remove_user,
+        routes::reorder_roles,
     ]
 }

--- a/titan-web-client/src/modules/organizations/organizationDetailScene.js
+++ b/titan-web-client/src/modules/organizations/organizationDetailScene.js
@@ -8,40 +8,6 @@ import { TabPanel } from 'titan/components/tabs/TabPanel';
 import { Overview } from 'titan/modules/organizations/organizationDetail/Overview';
 import { Reports } from 'titan/modules/organizations/organizationDetail/Reports';
 import { Members } from 'titan/modules/organizations/organizationDetail/Members';
-<<<<<<< 67f4a5945a2e7030b85e79911e9431216c1bd715
-
-class OrganizationDetailSceneComponent extends React.Component {
-  constructor (props) {
-    super(props);
-
-    this.organizationsService = new OrganizationsService();
-    this.state = {
-      chainOfCommand: [],
-      hasLocalCocRole: false,
-      isMemberOfCoc: false,
-      loading: true,
-      organization: null,
-      tab: 0
-    };
-  }
-
-  componentDidMount () {
-    this.init();
-  }
-
-  componentDidUpdate (prevProps, prevState, snapshot) {
-    if (prevProps.match.params.slug !== this.props.match.params.slug) {
-      this.init();
-    }
-  }
-
-  init () {
-    this.organizationsService.findBySlug(this.props.match.params.slug)
-      .then((res) => {
-        this.setState({ organization: res.data });
-        return this.organizationsService.findChainOfCommand(
-          res.data.id);
-=======
 import * as orgActions from 'titan/actions/organizationActions';
 import {
   GetOrganizationBySlugRequest,
@@ -68,7 +34,6 @@ export function OrganizationDetailScene () {
         dispatch(orgActions.setDetails(res.data));
         return makeTitanApiRequest(ListOrganizationChainOfCommandRequest,
           { id: res.data.id });
->>>>>>> Refactored organization state management
       })
       .then(res => {
         const coc = res.data.local_coc.concat(res.data.extended_coc);


### PR DESCRIPTION
Resolves #158.

Adds an API endpoint that reorders the rank an organization's roles, effectively changing it's CoC. The role management UI will leverage this endpoint for creating new roles within an organization. Users will give the role a name and assignee, then drag it into the appropriate position in the org's CoC.

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
