### PR TITLE
#165 Reload user permissions on page reload

### DIFF
--- a/titan-web-client/src/components/core/SessionCredentialLoader.js
+++ b/titan-web-client/src/components/core/SessionCredentialLoader.js
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import styled from 'styled-components';
+import {
+  AuthWoltlabLoginRequest,
+  makeTitanApiRequest
+} from 'titan/http/ApiClient';
+import { getAppContext } from 'titan/titan';
+import * as authActions from 'titan/actions/authActions';
+
+const StyledLoaderContainer = styled.div`
+  position: absolute;
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    left: calc(50% - 20px);
+    top: calc(50% - 20px);
+`;
+
+const appContext = getAppContext();
+
+export function SessionCredentialLoader (props) {
+  const dispatch = useDispatch();
+  const authUser = useSelector(
+    state => state.auth);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const userId = appContext.getCookies().get('wcf21_userID', {
+      domain: appContext.getConfig().get('woltlab.cookie.domain')
+    });
+    const token = appContext.getCookies().get('wcf21_password', {
+      domain: appContext.getConfig().get('woltlab.cookie.domain')
+    });
+
+    // Refreshing user credentials and permissions can have the
+    // side-effect of signing in the user. To avoid conflicting
+    // with the login view, check if the user is logged in already
+    // before attempting to refresh credentials.
+    if (!authUser || !userId || !token) {
+      setLoading(false);
+      return;
+    }
+
+    const authRequest = makeTitanApiRequest(AuthWoltlabLoginRequest, {
+      userId: parseInt(userId, 10),
+      token
+    });
+
+    authRequest
+      .then(res => {
+        dispatch(authActions.login(res.data));
+      })
+      .catch(() => {
+        // Do nothing. If there is an issue with the user's
+        // credentials, the subsequently loaded auth components will
+        // handle it.
+      })
+      .finally(() => {
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return (
+      <StyledLoaderContainer>
+        <CircularProgress />
+      </StyledLoaderContainer>
+    );
+  }
+
+  return props.children;
+}

--- a/titan-web-client/src/components/core/TitanApp.js
+++ b/titan-web-client/src/components/core/TitanApp.js
@@ -13,6 +13,7 @@ import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import { SnackbarProvider } from 'notistack';
 import { MatPickerDateUtils } from 'titan/lib/matPickerDateUtils';
+import { SessionCredentialLoader } from 'titan/components/core/SessionCredentialLoader';
 
 const defaultMuiTheme = createMuiTheme(defaultTheme);
 
@@ -84,12 +85,14 @@ class TitanApp extends React.Component {
           <MuiPickersUtilsProvider utils={MatPickerDateUtils}>
             <div id="app-root">
               <Provider store={this.props.context.getStore()}>
-                <BrowserRouter>
-                  <Switch>
-                    {this.renderRoutes(this.props.context.getRoutes())}
-                    <Redirect from="/" to="/organizations" />
-                  </Switch>
-                </BrowserRouter>
+                <SessionCredentialLoader>
+                  <BrowserRouter>
+                    <Switch>
+                      {this.renderRoutes(this.props.context.getRoutes())}
+                      <Redirect from="/" to="/organizations" />
+                    </Switch>
+                  </BrowserRouter>
+                </SessionCredentialLoader>
               </Provider>
             </div>
           </MuiPickersUtilsProvider>

--- a/titan-web-client/src/http/ApiClient.js
+++ b/titan-web-client/src/http/ApiClient.js
@@ -183,6 +183,26 @@ export function ListOrganizationChainOfCommandRequest (fields) {
 }
 
 /**
+ * Login using woltlab credentials.
+ *
+ * @param {{userId: string, token: string}} fields
+ * @returns {{auth: boolean, config: {method: string, url: string}}}
+ */
+export function AuthWoltlabLoginRequest (fields) {
+  return {
+    auth: false,
+    config: {
+      url: '/auth/woltlab',
+      method: 'post',
+      data: {
+        cookie_password: fields.token,
+        user_id: fields.userId
+      }
+    }
+  };
+}
+
+/**
  * React hook for sending requests to Titan's API services.
  *
  * @param {Function<{


### PR DESCRIPTION
## Reloads user credentials on hard page load
Once the initial app is loaded, permissions will not fetched again as users navigate through the app.

![titan_reload_creds_1](https://user-images.githubusercontent.com/2666285/66706419-1f67af00-ece7-11e9-8856-e2be45fa8189.png)

## Shows loading state while fetching user profile
![titan_reload_creds_3](https://user-images.githubusercontent.com/2666285/66706440-5b027900-ece7-11e9-8ee2-2a2782665e75.png)

    ```
    git rebase -i $(git merge-base HEAD master)
    git push origin NAME_OF_BRANCH --force-with-lease
    ```
